### PR TITLE
support to read specs from remote servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,10 @@ Well one handy thing about a specification is that, well its a specification.  T
 
     ./swagger-to-markdown.rb -r resources.json -p parameters.json -n Demo -o test.md -s pet.json
 
+or reading from a remote server:
+
+    ./swagger-to-markdown.rb -r resources.json -p parameters.json -n Demo -o test.md -s http://petstore.swagger.wordnik.com/api/pet.json
+
 #Demo 0.2 REST API
 Base Path: http://petstore.swagger.wordnik.com/api
 

--- a/swagger-to-markdown.rb
+++ b/swagger-to-markdown.rb
@@ -7,6 +7,7 @@ require 'net/http'
 require 'titleize'
 require 'optparse'
 require 'ostruct'
+require 'open-uri'
 
 class SwaggerToMarkdown
   def self.enhance(options)
@@ -189,7 +190,7 @@ class SwaggerToMarkdown
   end
 
   def self.extract_json(file_name)
-    file = File.open(file_name)
+    file = open(file_name)
     json = JSON.parse(file.read)
   end
 


### PR DESCRIPTION
included `open-uri` which makes reading file/url transparent.  Now you can generate the docs from a remote service.
